### PR TITLE
Add support to connect to SMTP server that does not require authentication credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Email Connector allows you to list, send emails and perform other actions su
 
 | Connector version | Supported WSO2 ESB/EI version |
 | ------------- |------------- |
+|  [1.0.1](https://github.com/wso2-extensions/esb-connector-email/tree/v1.0.1)        |  EI 6.6.0, EI 7.0.x, EI 7.1 |
 |  [1.0.0](https://github.com/wso2-extensions/esb-connector-email/tree/v1.0.0)        |  EI 6.6.0, EI 7.0.x |
 
 ## Documentation

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.emailconnector</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Connector For email</name>
     <url>http://wso2.org</url>

--- a/src/main/java/org/wso2/carbon/connector/operations/EmailConfig.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/EmailConfig.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.connector.operations;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.SynapseEnvironment;
@@ -88,11 +89,14 @@ public class EmailConfig extends AbstractConnector implements ManagedLifecycle {
                 EmailConstants.SSL_PROTOCOLS);
         String cipherSuites = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
                 EmailConstants.CIPHER_SUITES);
+        String requireAuthentication = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
+                EmailConstants.REQUIRE_AUTHENTICATION);
 
         ConnectionConfiguration connectionConfiguration = new ConnectionConfiguration();
         connectionConfiguration.setHost(host);
         connectionConfiguration.setPort(port);
         connectionConfiguration.setConnectionName(connectionName);
+        connectionConfiguration.setRequireAuthentication(requireAuthentication);
         connectionConfiguration.setPassword(password);
         connectionConfiguration.setProtocol(protocol);
         connectionConfiguration.setReadTimeout(readTimeout);

--- a/src/main/java/org/wso2/carbon/connector/pojo/ConnectionConfiguration.java
+++ b/src/main/java/org/wso2/carbon/connector/pojo/ConnectionConfiguration.java
@@ -37,6 +37,7 @@ public class ConnectionConfiguration {
     private String connectionTimeout;
     private String writeTimeout;
     private boolean requireTLS;
+    private boolean requireAuthentication = true;
     private boolean checkServerIdentity;
     private String trustedHosts;
     private String sslProtocols;
@@ -99,8 +100,8 @@ public class ConnectionConfiguration {
 
     public void setUsername(String username) throws InvalidConfigurationException {
 
-        if (StringUtils.isEmpty(username)) {
-            throw new InvalidConfigurationException("Mandatory parameter 'username' is not set.");
+        if (StringUtils.isEmpty(username) && getRequireAuthentication()) {
+            throw new InvalidConfigurationException("Server requires authentication, mandatory parameter 'username' is not set.");
         }
         this.username = username;
     }
@@ -112,8 +113,8 @@ public class ConnectionConfiguration {
 
     public void setPassword(String password) throws InvalidConfigurationException {
 
-        if (StringUtils.isEmpty(password)) {
-            throw new InvalidConfigurationException("Mandatory parameter 'password' is not set.");
+        if (StringUtils.isEmpty(password) && getRequireAuthentication()) {
+            throw new InvalidConfigurationException("Server requires authentication, mandatory parameter 'password' is not set.");
         }
         this.password = password;
     }
@@ -297,5 +298,17 @@ public class ConnectionConfiguration {
     public void setConfiguration(Configuration configuration) {
 
         this.configuration = configuration;
+    }
+
+    public void setRequireAuthentication(String requireAuthentication) {
+
+        if (!StringUtils.isEmpty(requireAuthentication)) {
+            this.requireAuthentication = Boolean.parseBoolean(requireAuthentication);
+        }
+    }
+
+    public Boolean getRequireAuthentication() {
+
+        return requireAuthentication;
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/utils/EmailConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/utils/EmailConstants.java
@@ -64,6 +64,7 @@ public final class EmailConstants {
     public static final String TRUSTED_HOSTS = "trustedHosts";
     public static final String SSL_PROTOCOLS = "sslProtocols";
     public static final String CIPHER_SUITES = "cipherSuites";
+    public static final String REQUIRE_AUTHENTICATION = "requireAuthentication";
     // Default email configuration values
     public static final String DEFAULT_SOCKETFACTORY_FALLBACK = "false";
     public static final String DEFAULT_FOLDER = "INBOX";

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -37,6 +37,7 @@
 	<parameter name="minEvictionTime" description="The minimum amount of time an object may sit idle in the pool before it is eligible for eviction"/>
 	<parameter name="evictionCheckInterval" description="The number of milliseconds between runs of the object evictor"/>
 	<parameter name="exhaustedAction" description="The behavior of the pool when the pool is exhausted."/>
+	<parameter name="requireAuthentication" description="Whether authentication is required for SMTP server."/>
 	<sequence>
 		<property name="host" expression="$func:host"/>
 		<property name="port" expression="$func:port"/>
@@ -58,6 +59,7 @@
 		<property name="minEvictionTime" expression="$func:minEvictionTime"/>
 		<property name="evictionCheckInterval" expression="$func:evictionCheckInterval"/>
 		<property name="exhaustedAction" expression="$func:exhaustedAction"/>
+		<property name="requireAuthentication" expression="$func:requireAuthentication"/>
 		<class name="org.wso2.carbon.connector.operations.EmailConfig" />
 	</sequence>
 </template>

--- a/src/main/resources/uischema/smtp.json
+++ b/src/main/resources/uischema/smtp.json
@@ -51,11 +51,22 @@
                 {
                   "type": "attribute",
                   "value": {
+                    "name": "requireAuthentication",
+                    "displayName": "Require Authentication",
+                    "inputType": "booleanOrExpression",
+                    "defaultValue": "true",
+                    "required": "true",
+                    "helpTip": "Whether authentication is required to connect with SMTP server"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
                     "name": "username",
                     "displayName": "Username",
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
-                    "required": "true",
+                    "required": "false",
                     "helpTip": "Username used to connect with the mail server"
                   }
                 },
@@ -66,7 +77,7 @@
                     "displayName": "Password",
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
-                    "required": "true",
+                    "required": "false",
                     "helpTip": "Password to connect with the mail server"
                   }
                 }


### PR DESCRIPTION
This PR makes Username and Password not mandatory for connecting with an SMTP server that does not require authentication credentials.
When the Username or Password is not required, the parameter `requireAuthentication` can be set to false.
Sample config:
```
<email.init>
        <requireAuthentication>false</requireAuthentication>
        <connectionType>SMTP</connectionType>
        <host>localhost</host>
        <port>2525</port>
        <name>EMAIL_CONNECTION_2</name>
</email.init>
```
Fixes https://github.com/wso2/product-ei/issues/5407

