### PR TITLE
Enable sending inline images in the HTML Content

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.emailconnector</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
     <name>WSO2 Carbon - Connector For email</name>
     <url>http://wso2.org</url>

--- a/src/main/java/org/wso2/carbon/connector/operations/EmailSend.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/EmailSend.java
@@ -86,6 +86,7 @@ public class EmailSend extends AbstractConnector {
         String subject = (String) getParameter(messageContext, EmailConstants.SUBJECT);
         String content = (String) getParameter(messageContext, EmailConstants.CONTENT);
         String attachments = (String) getParameter(messageContext, EmailConstants.ATTACHMENTS);
+        String inlineImages = (String) getParameter(messageContext, EmailConstants.INLINE_IMAGES);
         String contentType = (String) getParameter(messageContext, EmailConstants.CONTENT_TYPE);
         String encoding = (String) getParameter(messageContext, EmailConstants.ENCODING);
         String contentTransferEncoding = (String) getParameter(messageContext, EmailConstants.CONTENT_TRANSFER_ENCODING);
@@ -103,6 +104,7 @@ public class EmailSend extends AbstractConnector {
                         .replyTo(replyTo)
                         .withSubject(subject)
                         .withBody(content, contentType, encoding, contentTransferEncoding)
+                        .withInlineImages(inlineImages)
                         .withAttachments(attachments)
                         .withHeaders(getEmailHeadersFromProperties(messageContext))
                         .build();
@@ -114,7 +116,7 @@ public class EmailSend extends AbstractConnector {
                 throw new EmailConnectionException(
                         format("Error occurred while sending the email with subject %s to %s.", subject, to), e);
             } catch (IOException e) {
-                throw new EmailConnectionException(format("Error occurred while adding attachments with subject %s " +
+                throw new EmailConnectionException(format("Error occurred while building MIME message with subject %s " +
                         "to the email to %s.", subject, to), e);
             }
         }

--- a/src/main/java/org/wso2/carbon/connector/utils/EmailConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/utils/EmailConstants.java
@@ -36,6 +36,7 @@ public final class EmailConstants {
     public static final String CONTENT_TYPE = "contentType";
     public static final String ENCODING = "encoding";
     public static final String ATTACHMENTS = "attachments";
+    public static final String INLINE_IMAGES = "inlineImages";
     public static final String CONTENT_TRANSFER_ENCODING = "contentTransferEncoding";
     public static final String CONNECTION_TYPE = "connectionType";
     public static final String HOST = "host";

--- a/src/main/resources/functions/send.xml
+++ b/src/main/resources/functions/send.xml
@@ -26,6 +26,7 @@
     <parameter name="contentType" description="Content Type of the body text"/>
     <parameter name="encoding" description="The character encoding of the body"/>
     <parameter name="attachments" description="The attachments that are sent along with the email body"/>
+    <parameter name="inlineImages" description="The inline images that should be embedded inline to email body"/>
     <parameter name="contentTransferEncoding" description="Encoding used to indicate the type of transformation that is used to represent the body in an acceptable manner for transport"/>
     <sequence>
         <property name="from" expression="$func:from"/>
@@ -39,6 +40,7 @@
         <property name="contentType" expression="$func:contentType"/>
         <property name="encoding" expression="$func:encoding"/>
         <property name="attachments" expression="$func:attachments"/>
+        <property name="inlineImages" expression="$func:inlineImages"/>
         <property name="contentTransferEncoding" expression="$func:contentTransferEncoding"/>
         <class name="org.wso2.carbon.connector.operations.EmailSend" />
     </sequence>

--- a/src/main/resources/uischema/send.json
+++ b/src/main/resources/uischema/send.json
@@ -117,6 +117,17 @@
                     "required": "false",
                     "helpTip": "Comma separated file paths of the attachments that are sent along with the email body"
                   }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "inlineImages",
+                    "displayName": "Inline Images",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "[]",
+                    "required": "false",
+                    "helpTip": "Array of comma separated inline images that should be embedded inline to email body"
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/api-manager/issues/1454

## Approach
We have introduced a new parameter named `inlineImages`, which is an JSONArray to insert inline image details. There are 2 methods where the user can add images

1. Providing file path
2. Base64Content

Sample payloads are as follows
1. Providing file path
```
{
    "from": "abc@gmail.com",
    "to": "xyz@gmail.com",
    "subject": "Sample email subject",
    "content": "<H1>dog</H1><img src=\"cid:dog\" alt=\"this is image of dog\"><br/><H1>cat</H1><img src=\"cid:cat\" alt=\"this is a cat\">",
    "inlineImages": [
        {
            "contentID": "dog",
            "filePath": "/Users/user/Documents/images/dog.jpeg"
        },
        {
            "contentID": "cat",
            "filePath": "/Users/user/Documents/images/cat.jpeg"
        }
    ],
    "contentType": "text/html"
}
```

2. Base64Content
```
{
    "from": "abc@gmail.com",
    "to": "xyz@gmail.com",
    "subject": "Sample email subject 2",
    "content": "<H1>flower</H1><img src=\"cid:flower\" alt=\"this is image of a flower\"><br/><H1>cat</H1><img src=\"cid:cat\" alt=\"this is a cat\">",
    "inlineImages": [
        {
            "contentID": "flower",
            "fileName": "flower.jpeg",
            "base64Content": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAY......"
        },
        {
            "contentID": "cat",
            "fileName": "cat.jpeg",
            "base64Content": "/9j/4AAQSkZJRgABAQEBLAEsAAD/4QBbRXhp...."
        }
    ],
    "contentType": "text/html"
}
```




