### PR TITLE
make client secret not required in AuthorizationCodeHandler as for specification and Update smtp uischemas to add oauth.

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/connection/oauth/AuthorizationCodeHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/connection/oauth/AuthorizationCodeHandler.java
@@ -17,6 +17,8 @@
 
 package org.wso2.carbon.connector.connection.oauth;
 
+import org.apache.commons.lang.StringUtils;
+
 /**
  * This class is used to handle Authorization code grant oauth.
  */
@@ -32,9 +34,12 @@ public class AuthorizationCodeHandler extends OAuthHandler {
 
     @Override
     protected String buildTokenRequestPayload() {
-        return OAuthConstants.REFRESH_TOKEN_GRANT_TYPE +
+        String payload = OAuthConstants.REFRESH_TOKEN_GRANT_TYPE +
                 OAuthConstants.PARAM_CLIENT_ID + getClientId() +
-                OAuthConstants.PARAM_CLIENT_SECRET + getClientSecret() +
                 OAuthConstants.PARAM_REFRESH_TOKEN + refreshToken;
+        if (StringUtils.isNotBlank(getClientSecret())) {
+            payload += OAuthConstants.PARAM_CLIENT_SECRET + getClientSecret();
+        }
+        return payload;
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/connection/oauth/OAuthUtils.java
+++ b/src/main/java/org/wso2/carbon/connector/connection/oauth/OAuthUtils.java
@@ -99,8 +99,7 @@ public class OAuthUtils {
         String clientSecret = oAuthConfig.getClientSecret();
         String refreshToken = oAuthConfig.getRefreshToken();
         String tokenUrl = oAuthConfig.getTokenUrl();
-        if (StringUtils.isBlank(clientId) || StringUtils.isBlank(clientSecret) ||
-                StringUtils.isBlank(refreshToken) || StringUtils.isBlank(tokenUrl)) {
+        if (StringUtils.isBlank(clientId) || StringUtils.isBlank(refreshToken) || StringUtils.isBlank(tokenUrl)) {
             throw new EmailConnectionException("Invalid configurations provided for authorization code grant type.");
         }
         return new AuthorizationCodeHandler(userName, clientId, clientSecret, refreshToken, tokenUrl,

--- a/src/main/resources/uischema/imap.json
+++ b/src/main/resources/uischema/imap.json
@@ -242,7 +242,12 @@
               "inputType": "stringOrExpression",
               "defaultValue": "",
               "required": "false",
-              "helpTip": "The refresh token generated (This is applicable for grant type AUTHORIZATION_CODE)"
+              "helpTip": "The refresh token generated (This is applicable for grant type AUTHORIZATION_CODE)",
+              "enableCondition": [
+                {
+                  "grantType": "AUTHORIZATION_CODE"
+                }
+              ]
             }
           },
           {
@@ -264,7 +269,12 @@
               "inputType": "stringOrExpression",
               "defaultValue": "",
               "required": "false",
-              "helpTip": "Scope (This is applicable for grant type CLIENT_CREDENTIALS)"
+              "helpTip": "Scope (This is applicable for grant type CLIENT_CREDENTIALS)",
+              "enableCondition": [
+                {
+                  "grantType": "CLIENT_CREDENTIALS"
+                }
+              ]
             }
           }
         ]

--- a/src/main/resources/uischema/imaps.json
+++ b/src/main/resources/uischema/imaps.json
@@ -140,7 +140,12 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "false",
-                    "helpTip": "The refresh token generated (This is applicable for grant type AUTHORIZATION_CODE)"
+                    "helpTip": "The refresh token generated (This is applicable for grant type AUTHORIZATION_CODE)",
+                    "enableCondition": [
+                      {
+                        "grantType": "AUTHORIZATION_CODE"
+                      }
+                    ]
                   }
                 },
                 {
@@ -162,7 +167,12 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "false",
-                    "helpTip": "Scope (This is applicable for grant type CLIENT_CREDENTIALS)"
+                    "helpTip": "Scope (This is applicable for grant type CLIENT_CREDENTIALS)",
+                    "enableCondition": [
+                      {
+                        "grantType": "CLIENT_CREDENTIALS"
+                      }
+                    ]
                   }
                 }
               ]

--- a/src/main/resources/uischema/smtp.json
+++ b/src/main/resources/uischema/smtp.json
@@ -94,6 +94,102 @@
         "groupName": "Advanced",
         "elements": [
           {
+            "type": "attributeGroup",
+            "value": {
+              "groupName": "OAuth2",
+              "elements": [
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "enableOAuth2",
+                    "displayName": "Enable OAuth2",
+                    "inputType": "booleanOrExpression",
+                    "defaultValue": "false",
+                    "required": "false",
+                    "helpTip": "Whether to enable OAuth2 Authentication"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "grantType",
+                    "displayName": "Grant Type",
+                    "inputType": "comboOrExpression",
+                    "comboValues": ["AUTHORIZATION_CODE","CLIENT_CREDENTIALS"],
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Grant type to generate access token"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "clientId",
+                    "displayName": "Client ID",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Value of the Client ID you obtained when you register your application"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "clientSecret",
+                    "displayName": "Client Secret",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Value of the Client Secret you obtained when you register your application"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "refreshToken",
+                    "displayName": "Refresh Token",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "The refresh token generated (This is applicable for grant type AUTHORIZATION_CODE)",
+                    "enableCondition": [
+                      {
+                        "grantType": "AUTHORIZATION_CODE"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "tokenUrl",
+                    "displayName": "Token URL",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "The token endpoint URL to generate access token"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "scope",
+                    "displayName": "Scope",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Scope (This is applicable for grant type CLIENT_CREDENTIALS)",
+                    "enableCondition": [
+                      {
+                        "grantType": "CLIENT_CREDENTIALS"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
             "type": "attribute",
             "value": {
               "name": "readTimeout",

--- a/src/main/resources/uischema/smtps.json
+++ b/src/main/resources/uischema/smtps.json
@@ -83,6 +83,102 @@
         "groupName": "Advanced",
         "elements": [
           {
+            "type": "attributeGroup",
+            "value": {
+              "groupName": "OAuth2",
+              "elements": [
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "enableOAuth2",
+                    "displayName": "Enable OAuth2",
+                    "inputType": "booleanOrExpression",
+                    "defaultValue": "false",
+                    "required": "false",
+                    "helpTip": "Whether to enable OAuth2 Authentication"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "grantType",
+                    "displayName": "Grant Type",
+                    "inputType": "comboOrExpression",
+                    "comboValues": ["AUTHORIZATION_CODE","CLIENT_CREDENTIALS"],
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Grant type to generate access token"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "clientId",
+                    "displayName": "Client ID",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Value of the Client ID you obtained when you register your application"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "clientSecret",
+                    "displayName": "Client Secret",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Value of the Client Secret you obtained when you register your application"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "refreshToken",
+                    "displayName": "Refresh Token",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "The refresh token generated (This is applicable for grant type AUTHORIZATION_CODE)",
+                    "enableCondition": [
+                      {
+                        "grantType": "AUTHORIZATION_CODE"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "tokenUrl",
+                    "displayName": "Token URL",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "The token endpoint URL to generate access token"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "scope",
+                    "displayName": "Scope",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Scope (This is applicable for grant type CLIENT_CREDENTIALS)",
+                    "enableCondition": [
+                      {
+                        "grantType": "CLIENT_CREDENTIALS"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
             "type": "attribute",
             "value": {
               "name": "readTimeout",


### PR DESCRIPTION
fixes: https://github.com/wso2/product-integrator-mi/issues/4772

This pull request introduces OAuth2 support for SMTP and SMTPS connections by updating both the backend logic and the UI schema configuration. The changes ensure that OAuth2 parameters are correctly handled and exposed in the UI, and that the backend logic gracefully handles cases where the client secret is optional in the authorization code flow.

**Backend logic improvements:**

* Made the `clientSecret` parameter optional in the authorization code grant flow by updating the payload construction in `AuthorizationCodeHandler`. The client secret is now only included if it is not blank.
* Updated validation logic in `OAuthUtils` to no longer require `clientSecret` for the authorization code handler, allowing for OAuth2 flows that do not need a client secret.
* Added missing import for `StringUtils` in `AuthorizationCodeHandler.java` to support the new null/blank check.

**UI schema enhancements:**

* Added an "OAuth2" attribute group to both `smtp.json` and `smtps.json` UI schema files, exposing configuration fields for enabling OAuth2, selecting the grant type, and specifying client credentials, refresh token, token URL, and scope. This allows users to configure OAuth2 authentication directly from the UI.
